### PR TITLE
Add group_test_cases option

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -620,12 +620,17 @@ def find_tests(binaries, additional_args, options, times):
       if line[0] != " ":
         # Remove comments for typed tests and strip whitespace.
         test_group = line.split('#')[0].strip()
-        continue
-      # Remove comments for parameterized tests and strip whitespace.
-      line = line.split('#')[0].strip()
-      if not line:
-        continue
-
+        if options.group_test_cases:
+          line = "*"
+        else:
+          continue
+      else:
+        if options.group_test_cases:
+          continue
+        # Remove comments for parameterized tests and strip whitespace.
+        line = line.split('#')[0].strip()
+        if not line:
+          continue
       test_name = test_group + line
       if not options.gtest_also_run_disabled_tests and 'DISABLED_' in test_name:
         continue
@@ -780,6 +785,10 @@ def default_options_parser():
                     default=False,
                     help='Do not run tests from the same test '
                     'case in parallel.')
+  parser.add_option('--group_test_cases',
+                    action='store_true',
+                    default=False,
+                    help='Run tests from the same test case in a single process.')
   return parser
 
 


### PR DESCRIPTION
The new option is similar to the serialize_test_cases option, but runs the whole test group in a single process. It is especially
advantageous in cases when launching executable is costly with relatively high constant overhead (e.g. due to dynamic linker mapping shared library symbols, static/global structure initialization etc.).

In such cases the cost is amortized to several test cases which may considerably speed the overall run time up (e.g. number of process startups is reduced by factor 4.5 which brings almost 4X speedup from 38s down to 10s in our case).